### PR TITLE
Update pxt.json

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -13,6 +13,7 @@
         "ReceiverIR.cpp",
         "ReceiverIR.h",
         "RemoteIR.h",
+        "Shims.d.ts",
         "TransmitterIR.cpp",
         "TransmitterIR.h",
         "_locales/zh/maqueen-strings.json"


### PR DESCRIPTION
Latest version of  MakeCode.microbit.org needs shims.d.ts specified in the Files section of pxt.json in order to import the maqueen code